### PR TITLE
feat:Add filter login into synth engine and gui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod synth {
     mod adsr;
     mod engine;
+    mod filter;
     mod note;
     mod osc;
     mod shared_bus;
     // Re-export primary types to avoid deep paths
     pub use engine::Synth;
+    pub use filter::FilterType;
     pub use note::Note;
     pub use osc::Waveform;
     pub use shared_bus::Msg;

--- a/src/synth/adsr.rs
+++ b/src/synth/adsr.rs
@@ -41,6 +41,13 @@ impl Adsr {
         }
     }
 
+    pub fn retune(&mut self, a: f32, d: f32, s: f32, r: f32) {
+        self.a = a;
+        self.d = d;
+        self.s = s.clamp(0.0, 1.0);
+        self.r = r;
+    }
+
     #[inline]
     fn set_stage(&mut self, time_sec: f32, target: f32) {
         self.target = target;

--- a/src/synth/filter.rs
+++ b/src/synth/filter.rs
@@ -1,0 +1,128 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FilterType {
+    OnePoleLpf(f32), // カットオフ周波数
+    TwoPoleLpf(f32),
+}
+
+#[derive(Clone, Copy)]
+pub enum Filter {
+    OnePoleLpf(OnePoleLpf),
+    TwoPoleLpf(TwoPoleLpf),
+}
+
+impl Default for Filter {
+    fn default() -> Self {
+        Self::OnePoleLpf(OnePoleLpf::new(44100.0, 2000.0))
+    }
+}
+
+impl Filter {
+    pub fn new(filter_type: FilterType, sr: f32) -> Self {
+        match filter_type {
+            FilterType::OnePoleLpf(cutoff) => Filter::OnePoleLpf(OnePoleLpf::new(sr, cutoff)),
+            FilterType::TwoPoleLpf(cutoff) => Filter::TwoPoleLpf(TwoPoleLpf::new(sr, cutoff)),
+        }
+    }
+}
+
+pub trait FilterTrait {
+    fn process(&mut self, input: f32) -> f32;
+    fn set_cutoff(&mut self, sr: f32, cutoff: f32);
+    fn reset(&mut self);
+}
+
+impl FilterTrait for Filter {
+    fn process(&mut self, x: f32) -> f32 {
+        match self {
+            Filter::OnePoleLpf(f) => f.process(x),
+            Filter::TwoPoleLpf(f) => f.process(x),
+        }
+    }
+    fn set_cutoff(&mut self, sr: f32, c: f32) {
+        match self {
+            Filter::OnePoleLpf(f) => f.set_cutoff(sr, c),
+            Filter::TwoPoleLpf(f) => f.set_cutoff(sr, c),
+        }
+    }
+    fn reset(&mut self) {
+        match self {
+            Filter::OnePoleLpf(f) => f.reset(),
+            Filter::TwoPoleLpf(f) => f.reset(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct OnePoleLpf {
+    cutoff: f32, // カットオフ周波数 [0 ~ sr/2]
+    a: f32,      // フィルタ係数
+    y1: f32,     // 前回の出力
+}
+
+impl OnePoleLpf {
+    pub fn new(sr: f32, cutoff: f32) -> Self {
+        let mut f = Self {
+            cutoff,
+            a: 0.0,
+            y1: 0.0,
+        };
+        f.set_cutoff(sr, cutoff);
+        f
+    }
+}
+
+impl FilterTrait for OnePoleLpf {
+    fn set_cutoff(&mut self, sr: f32, cutoff: f32) {
+        self.cutoff = cutoff;
+        self.a = 2.0 * std::f32::consts::PI * cutoff / sr;
+    }
+
+    fn process(&mut self, input: f32) -> f32 {
+        self.y1 += self.a * (input - self.y1);
+        self.y1
+    }
+
+    fn reset(&mut self) {
+        self.y1 = 0.0;
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct TwoPoleLpf {
+    cutoff: f32,
+    a: f32,  // フィルタ係数
+    y1: f32, // 前回の出力
+    y2: f32, // 2回前の出力
+}
+
+impl TwoPoleLpf {
+    pub fn new(sr: f32, cutoff: f32) -> Self {
+        let mut f = Self {
+            cutoff,
+            a: 0.0,
+            y1: 0.0,
+            y2: 0.0,
+        };
+        f.set_cutoff(sr, cutoff);
+        f
+    }
+}
+
+impl FilterTrait for TwoPoleLpf {
+    fn set_cutoff(&mut self, sr: f32, cutoff: f32) {
+        self.cutoff = cutoff;
+        self.a = 2.0 * std::f32::consts::PI * cutoff / sr;
+    }
+
+    fn process(&mut self, input: f32) -> f32 {
+        let y = self.y1 + self.a * (input - self.y1) + self.a * (self.y1 - self.y2);
+        self.y2 = self.y1;
+        self.y1 = y;
+        y
+    }
+
+    fn reset(&mut self) {
+        self.y1 = 0.0;
+        self.y2 = 0.0;
+    }
+}

--- a/src/synth/shared_bus.rs
+++ b/src/synth/shared_bus.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crossbeam::queue::ArrayQueue;
 
-use crate::synth::{Note, osc::Waveform};
+use crate::synth::{FilterType, Note, osc::Waveform};
 
 const QUEUE_CAP: usize = 2048;
 
@@ -13,6 +13,7 @@ pub enum Msg {
     SetMasterVolume(f32),
     SetAdsr { a: f32, d: f32, s: f32, r: f32 },
     SetWaveform(Waveform),
+    SetFilter(Option<FilterType>),
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This pull request introduces a filter feature to the synthesizer, allowing users to enable and configure low-pass filters (OnePole and TwoPole) directly from the GUI. The changes span the GUI, synth engine, messaging, and audio stream setup to support dynamic filter control per voice.

**Synth Filter Feature Integration**

_Filter types and processing:_

* Added a new `FilterType` enum and `Filter` struct in `src/synth/filter.rs`, supporting both OnePole and TwoPole low-pass filters, with trait-based processing and cutoff control.
* Synth voices now hold an optional filter, and filter processing is applied to oscillator output in the engine. Filter parameters can be updated or reset per voice. [[1]](diffhunk://#diff-b81b704384f02e1767807dbb690d9f03007b4ec25ab0d1a100686852635705a1R15) [[2]](diffhunk://#diff-b81b704384f02e1767807dbb690d9f03007b4ec25ab0d1a100686852635705a1R88-R92) [[3]](diffhunk://#diff-b81b704384f02e1767807dbb690d9f03007b4ec25ab0d1a100686852635705a1L98-R146)

_GUI and user interaction:_

* The GUI (`src/gui/app.rs`) now includes controls for enabling/disabling the filter, selecting filter type, and adjusting cutoff frequency. These settings are sent to the synth engine via the message bus. [[1]](diffhunk://#diff-0677dc48ec93346b9eb07366b8e228e2e0f6b5ac0d659e92b9e0c83251cef838R12-R33) [[2]](diffhunk://#diff-0677dc48ec93346b9eb07366b8e228e2e0f6b5ac0d659e92b9e0c83251cef838L44-R159)

_Messaging and stream setup:_

* Extended the message bus (`Msg` enum) to support filter parameter changes, and updated main stream setup to initialize and propagate filter settings. [[1]](diffhunk://#diff-b1e9bb955d5aec2e1f61b549c429ee1770a786fc64ab0b673c6ff1526c99c064R16) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR71-R79) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR92) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR43)

_Codebase structure:_

* Refactored imports and module exports to expose filter types and integrate them throughout the synth codebase (`src/lib.rs`, `src/main.rs`). [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R4-R10) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL9-R9) [[3]](diffhunk://#diff-b1e9bb955d5aec2e1f61b549c429ee1770a786fc64ab0b673c6ff1526c99c064L5-R5)

These changes collectively enable flexible, real-time filter control in the synthesizer, enhancing sound design capabilities from the user interface.