### PR TITLE
feat:Add TwoPoleLpf for lpf with resonance params

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
             channels,
             sample_rate,
             waveform: Waveform::Sine,
-            filter: Some(FilterType::OnePoleLpf(1000.0)),
+            filter: None,
             err_fn: Box::new(|err| eprintln!("an error occurred on stream: {}", err)),
         })
         .expect("Failed to build stream"),

--- a/src/synth/engine.rs
+++ b/src/synth/engine.rs
@@ -136,8 +136,8 @@ impl Synth {
                 (Some(FilterType::OnePoleLpf(c)), Some(Filter::OnePoleLpf(f))) => {
                     f.set_cutoff(self.sr, c); // 型は同じ → 係数更新だけ
                 }
-                (Some(FilterType::TwoPoleLpf(c)), Some(Filter::TwoPoleLpf(f))) => {
-                    f.set_cutoff(self.sr, c); // 型は同じ → 係数更新だけ
+                (Some(FilterType::TwoPoleLpf(c, q)), Some(Filter::TwoPoleLpf(f))) => {
+                    f.set_params(self.sr, c, q);
                 }
                 (Some(ft), Some(_old_other_type)) => {
                     // 型が変わる → 作り直す（必要なら新規に reset 済み）

--- a/src/synth/filter.rs
+++ b/src/synth/filter.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FilterType {
-    OnePoleLpf(f32), // カットオフ周波数
-    TwoPoleLpf(f32),
+    OnePoleLpf(f32),      // カットオフ周波数
+    TwoPoleLpf(f32, f32), // カットオフ周波数とレゾナンス
 }
 
 #[derive(Clone, Copy)]
@@ -10,24 +10,17 @@ pub enum Filter {
     TwoPoleLpf(TwoPoleLpf),
 }
 
-impl Default for Filter {
-    fn default() -> Self {
-        Self::OnePoleLpf(OnePoleLpf::new(44100.0, 2000.0))
-    }
-}
-
 impl Filter {
     pub fn new(filter_type: FilterType, sr: f32) -> Self {
         match filter_type {
             FilterType::OnePoleLpf(cutoff) => Filter::OnePoleLpf(OnePoleLpf::new(sr, cutoff)),
-            FilterType::TwoPoleLpf(cutoff) => Filter::TwoPoleLpf(TwoPoleLpf::new(sr, cutoff)),
+            FilterType::TwoPoleLpf(cutoff, q) => Filter::TwoPoleLpf(TwoPoleLpf::new(sr, cutoff, q)),
         }
     }
 }
 
 pub trait FilterTrait {
     fn process(&mut self, input: f32) -> f32;
-    fn set_cutoff(&mut self, sr: f32, cutoff: f32);
     fn reset(&mut self);
 }
 
@@ -36,12 +29,6 @@ impl FilterTrait for Filter {
         match self {
             Filter::OnePoleLpf(f) => f.process(x),
             Filter::TwoPoleLpf(f) => f.process(x),
-        }
-    }
-    fn set_cutoff(&mut self, sr: f32, c: f32) {
-        match self {
-            Filter::OnePoleLpf(f) => f.set_cutoff(sr, c),
-            Filter::TwoPoleLpf(f) => f.set_cutoff(sr, c),
         }
     }
     fn reset(&mut self) {
@@ -71,12 +58,16 @@ impl OnePoleLpf {
     }
 }
 
-impl FilterTrait for OnePoleLpf {
-    fn set_cutoff(&mut self, sr: f32, cutoff: f32) {
-        self.cutoff = cutoff;
-        self.a = 2.0 * std::f32::consts::PI * cutoff / sr;
+impl OnePoleLpf {
+    pub fn set_cutoff(&mut self, sr: f32, cutoff: f32) {
+        self.cutoff = cutoff.clamp(0.0, 0.49 * sr);
+        let rc = 1.0 / (2.0 * std::f32::consts::PI * self.cutoff.max(1e-6));
+        let dt = 1.0 / sr;
+        self.a = dt / (rc + dt);
     }
+}
 
+impl FilterTrait for OnePoleLpf {
     fn process(&mut self, input: f32) -> f32 {
         self.y1 += self.a * (input - self.y1);
         self.y1
@@ -90,34 +81,65 @@ impl FilterTrait for OnePoleLpf {
 #[derive(Clone, Copy, Default)]
 pub struct TwoPoleLpf {
     cutoff: f32,
-    a: f32,  // フィルタ係数
-    y1: f32, // 前回の出力
-    y2: f32, // 2回前の出力
+    q: f32, // レゾナンス
+    b0: f32,
+    b1: f32,
+    b2: f32,
+    a1: f32,
+    a2: f32, // フィルタ係数
+    y1: f32,
+    y2: f32, // 前回の出力
 }
 
 impl TwoPoleLpf {
-    pub fn new(sr: f32, cutoff: f32) -> Self {
+    pub fn new(sr: f32, cutoff: f32, q: f32) -> Self {
         let mut f = Self {
             cutoff,
-            a: 0.0,
+            q,
+            b0: 0.0,
+            b1: 0.0,
+            b2: 0.0,
+            a1: 0.0,
+            a2: 0.0,
             y1: 0.0,
             y2: 0.0,
         };
-        f.set_cutoff(sr, cutoff);
+        f.update_coefficients(sr);
         f
+    }
+
+    pub fn set_params(&mut self, sr: f32, cutoff: f32, q: f32) {
+        self.cutoff = cutoff;
+        self.q = q;
+        self.update_coefficients(sr);
+    }
+
+    pub fn update_coefficients(&mut self, sr: f32) {
+        let f0 = self.cutoff.clamp(1.0, 0.49 * sr);
+        let w0 = 2.0 * std::f32::consts::PI * f0 / sr;
+        let (sw, cw0) = w0.sin_cos();
+        let alpha = sw / (2.0 * self.q.max(1e-6));
+
+        let b0 = (1.0 - cw0) / 2.0;
+        let b1 = 1.0 - cw0;
+        let b2 = (1.0 - cw0) / 2.0;
+        let a0 = 1.0 + alpha;
+        let a1 = -2.0 * cw0;
+        let a2 = 1.0 - alpha;
+
+        self.b1 = b0 / a0; // 正規化された係数
+        self.b1 = b1 / a0;
+        self.b2 = b2 / a0;
+        self.a1 = a1 / a0;
+        self.a2 = a2 / a0;
     }
 }
 
 impl FilterTrait for TwoPoleLpf {
-    fn set_cutoff(&mut self, sr: f32, cutoff: f32) {
-        self.cutoff = cutoff;
-        self.a = 2.0 * std::f32::consts::PI * cutoff / sr;
-    }
-
     fn process(&mut self, input: f32) -> f32 {
-        let y = self.y1 + self.a * (input - self.y1) + self.a * (self.y1 - self.y2);
-        self.y2 = self.y1;
-        self.y1 = y;
+        let y = self.b0 * input + self.y1;
+        self.y1 = self.b1 * input - self.a1 * y + self.y2;
+        self.y2 = self.b2 * input - self.a2 * y;
         y
     }
 


### PR DESCRIPTION
This pull request adds support for resonance (Q) control to the two-pole low-pass filter in the synth application and updates the GUI to allow users to adjust this parameter. The changes include updates to the filter data structures, GUI controls, and filter coefficient calculations, enabling more flexible and accurate filter behavior.

### Filter architecture and parameter updates

* The `FilterType::TwoPoleLpf` variant now takes both cutoff and resonance (Q) parameters, allowing for more expressive filter control.
* The internal structure of `TwoPoleLpf` has been expanded to store resonance and filter coefficients, and the filter's coefficient calculation now uses both cutoff and Q for improved accuracy. The method for updating coefficients was refactored into `update_coefficients`, and the filter's processing logic was updated accordingly.

### GUI enhancements

* The GUI now includes a slider for resonance (Q) when the two-pole filter is selected, enabling users to adjust this parameter interactively. The filter struct and initialization were updated to support Q. [[1]](diffhunk://#diff-0677dc48ec93346b9eb07366b8e228e2e0f6b5ac0d659e92b9e0c83251cef838L22-R33) [[2]](diffhunk://#diff-0677dc48ec93346b9eb07366b8e228e2e0f6b5ac0d659e92b9e0c83251cef838R50) [[3]](diffhunk://#diff-0677dc48ec93346b9eb07366b8e228e2e0f6b5ac0d659e92b9e0c83251cef838R129-R145)

### Integration and message passing

* The message passing logic for filter changes now includes both cutoff and Q for the two-pole filter, ensuring the synth engine receives all necessary parameters. [[1]](diffhunk://#diff-0677dc48ec93346b9eb07366b8e228e2e0f6b5ac0d659e92b9e0c83251cef838L154-R168) [[2]](diffhunk://#diff-b81b704384f02e1767807dbb690d9f03007b4ec25ab0d1a100686852635705a1L139-R140)

### Code cleanup and defaults

* The default filter is now set to `None` in the main application, and unused default implementations for filters were removed for clarity. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL43-R43) [[2]](diffhunk://#diff-9df904382d7857cfe0841bae1774183f8f8d2d3fd21be2e597ceeb5b6fdee7c3L13-L30)