### PR TITLE
feat(web): add wasm UI + GitHub Pages deploy via Trunk

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Web (Pages)
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build wasm (trunk)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust (stable + wasm target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install trunk
+        run: cargo install trunk
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build (trunk)
+        run: trunk build --release --public-url "/${{ github.event.repository.name }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,9 +1099,11 @@ dependencies = [
 name = "kbd_synth_min"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "cpal",
  "crossbeam",
  "eframe",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,14 @@ name = "kbd_synth_min"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 cpal = "0.16.0"
 crossbeam = "0.8.4"
 eframe = { version = "0.32.1", default-features = false, features = ["glow", "default_fonts", "wayland"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = "0.1"

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>kbd_synth_min (Web)</title>
+    <!-- Build the crate to wasm via Trunk -->
+    <link data-trunk rel="rust" data-wasm-opt="z" />
+    <!-- Set correct base path when hosted on GitHub Pages -->
+    <base data-trunk-public-url />
+    <style>
+      html, body { height: 100%; width: 100%; margin: 0; }
+      canvas { height: 100%; width: 100%; display: block; }
+    </style>
+  </head>
+  <body>
+    <canvas id="the_canvas_id"></canvas>
+  </body>
+  </html>
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,25 @@ pub mod gui {
     mod app;
     pub use app::EguiUi;
 }
+
+// WASM entry point for web build
+#[cfg(target_arch = "wasm32")]
+mod web_entry {
+    use crate::{gui::EguiUi, synth::SharedBus};
+    use eframe::WebOptions;
+    use wasm_bindgen::prelude::*;
+
+    // Better error messages in the browser console on panic
+    #[wasm_bindgen(start)]
+    pub async fn start() -> Result<(), JsValue> {
+        console_error_panic_hook::set_once();
+
+        let options = WebOptions::default();
+        eframe::start_web(
+            "the_canvas_id",
+            options,
+            Box::new(|_cc| Box::new(EguiUi::new(SharedBus::default()))),
+        )
+        .await
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use kbd_synth_min::{
     synth::{FilterType, Msg, SharedBus, Synth, Waveform},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
     // デバイスと出力設定
     let host = cpal::default_host();


### PR DESCRIPTION
This pull request introduces support for building and deploying the `kbd_synth_min` project as a WebAssembly (WASM) application to GitHub Pages. It adds the necessary configuration for web deployment, updates dependencies and build settings for WASM compatibility, and implements a web-specific entry point. Additionally, it refines the keyboard-to-note mapping logic for improved usability.

**Web deployment and WASM support:**

* Added `.github/workflows/gh-pages.yml` to automate building the WASM app and deploying it to GitHub Pages on pushes to the `develop` branch.
* Updated `Cargo.toml` to set the crate type for WASM builds and include WASM-specific dependencies (`wasm-bindgen`, `console_error_panic_hook`).
* Added `index.html` for the web frontend, configured for Trunk-based WASM builds and GitHub Pages hosting.
* Implemented a WASM entry point in `src/lib.rs` using `eframe::start_web` for browser initialization, with improved panic error reporting.
* Updated `src/main.rs` to ensure the native `main` function is only compiled for non-WASM targets.

**Keyboard mapping improvements:**

* Refined the mapping from `egui::Key` to `Note` in `src/gui/app.rs` to use a more intuitive set of keys for musical notes, improving playability on web and desktop.