### PR TITLE
ci(pages): remove configure-pages step (Pages configured manually)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install trunk
         run: cargo install trunk
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-
       - name: Build (trunk)
         run: trunk build --release --public-url "/${{ github.event.repository.name }}/"
 
@@ -55,4 +52,3 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow for deploying to GitHub Pages. The main change is the removal of the step that configures Pages using the `actions/configure-pages` action, streamlining the deployment process.

* Removed the `Configure Pages` step (`actions/configure-pages@v5`) from the `.github/workflows/gh-pages.yml` workflow to simplify the deployment pipeline.
* Cleaned up the workflow by removing an unnecessary blank line after the `Deploy` step in `.github/workflows/gh-pages.yml`.