### PR TITLE
Feature/add GitHub page for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "crossbeam",
  "eframe",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ eframe = { version = "0.32.1", default-features = false, features = ["glow", "de
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
+wasm-bindgen-futures = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod gui {
 #[cfg(target_arch = "wasm32")]
 mod web_entry {
     use crate::{gui::EguiUi, synth::SharedBus};
-    use eframe::WebOptions;
+    use eframe::{WebOptions, WebRunner};
     use wasm_bindgen::prelude::*;
 
     // Better error messages in the browser console on panic
@@ -32,11 +32,13 @@ mod web_entry {
         console_error_panic_hook::set_once();
 
         let options = WebOptions::default();
-        eframe::start_web(
-            "the_canvas_id",
-            options,
-            Box::new(|_cc| Box::new(EguiUi::new(SharedBus::default()))),
-        )
-        .await
+        let runner = WebRunner::new();
+        runner
+            .start(
+                "the_canvas_id",
+                options,
+                Box::new(|_cc| Box::new(EguiUi::new(SharedBus::default()))),
+            )
+            .await
     }
 }


### PR DESCRIPTION
This pull request introduces web (WASM) support for the `kbd_synth_min` project, enabling deployment to GitHub Pages and updating the keyboard mapping for note input. The changes include new build and deployment workflows, configuration updates for WASM, a web entry point, and a revised mapping of keyboard keys to musical notes for improved usability.

**Web/WASM support and deployment:**

* Added a GitHub Actions workflow (`.github/workflows/gh-pages.yml`) to automate building the WASM version using Trunk and deploying it to GitHub Pages.
* Updated `Cargo.toml` to specify WASM dependencies and crate types (`cdylib`, `rlib`) for building the web version.
* Added a minimal `index.html` for the web build, including Trunk integration and a canvas element for rendering the UI.
* Implemented a WASM entry point in `src/lib.rs` using `eframe` and `wasm-bindgen`, with improved browser error reporting.
* Updated `src/main.rs` to ensure the native entry point is excluded from WASM builds.

**Keyboard mapping improvements:**

* Revised the mapping of `egui::Key` values to musical notes in `src/gui/app.rs`, making the note input more intuitive and consistent with common keyboard layouts.