### PR TITLE
Feature/add GitHub page for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
  "eframe",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,15 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cpal = "0.16.0"
 crossbeam = "0.8.4"
-eframe = { version = "0.32.1", default-features = false, features = ["glow", "default_fonts", "wayland"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
 wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["Window", "Document", "HtmlCanvasElement"] }
+eframe = { version = "0.32.1", default-features = false, features = ["glow", "default_fonts"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cpal = "0.16.0"
+eframe = { version = "0.32.1", default-features = false, features = ["glow", "default_fonts", "wayland"] }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>kbd_synth_min (Web)</title>
     <!-- Build the crate to wasm via Trunk -->
-    <link data-trunk rel="rust" data-wasm-opt="z" />
+    <link data-trunk rel="rust" data-wasm-opt="z" data-cargo-args="--lib" />
     <!-- Set correct base path when hosted on GitHub Pages -->
     <base data-trunk-public-url />
     <style>
@@ -17,4 +17,3 @@
     <canvas id="the_canvas_id"></canvas>
   </body>
   </html>
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub mod gui {
 mod web_entry {
     use crate::{gui::EguiUi, synth::SharedBus};
     use eframe::{App, WebOptions, WebRunner};
-    use wasm_bindgen::prelude::*;
     use wasm_bindgen::JsCast;
+    use wasm_bindgen::prelude::*;
 
     // Better error messages in the browser console on panic
     #[wasm_bindgen(start)]
@@ -48,9 +48,11 @@ mod web_entry {
             .start(
                 canvas,
                 options,
-                Box::new(|_cc| -> Result<Box<dyn App>, Box<dyn std::error::Error + Send + Sync>> {
-                    Ok(Box::new(EguiUi::new(SharedBus::default())))
-                }),
+                Box::new(
+                    |_cc| -> Result<Box<dyn App>, Box<dyn std::error::Error + Send + Sync>> {
+                        Ok(Box::new(EguiUi::new(SharedBus::default())))
+                    },
+                ),
             )
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,21 +23,34 @@ pub mod gui {
 #[cfg(target_arch = "wasm32")]
 mod web_entry {
     use crate::{gui::EguiUi, synth::SharedBus};
-    use eframe::{WebOptions, WebRunner};
+    use eframe::{App, WebOptions, WebRunner};
     use wasm_bindgen::prelude::*;
+    use wasm_bindgen::JsCast;
 
     // Better error messages in the browser console on panic
     #[wasm_bindgen(start)]
     pub async fn start() -> Result<(), JsValue> {
         console_error_panic_hook::set_once();
 
+        let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+        let document = window
+            .document()
+            .ok_or_else(|| JsValue::from_str("no document"))?;
+        let canvas = document
+            .get_element_by_id("the_canvas_id")
+            .ok_or_else(|| JsValue::from_str("canvas not found"))?
+            .dyn_into::<web_sys::HtmlCanvasElement>()
+            .map_err(|_| JsValue::from_str("failed to cast to HtmlCanvasElement"))?;
+
         let options = WebOptions::default();
         let runner = WebRunner::new();
         runner
             .start(
-                "the_canvas_id",
+                canvas,
                 options,
-                Box::new(|_cc| Box::new(EguiUi::new(SharedBus::default()))),
+                Box::new(|_cc| -> Result<Box<dyn App>, Box<dyn std::error::Error + Send + Sync>> {
+                    Ok(Box::new(EguiUi::new(SharedBus::default())))
+                }),
             )
             .await
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 use cpal::{
     SampleFormat, StreamConfig,
     traits::{DeviceTrait, HostTrait, StreamTrait},


### PR DESCRIPTION
This pull request improves platform-specific support and web integration for the project. The main changes include refactoring dependency management in `Cargo.toml` to separate native and web dependencies, updating the web entry point to use a more robust method for accessing the canvas element, and making minor build and configuration adjustments.

**Platform-specific dependency management:**

* Refactored `Cargo.toml` to separate dependencies for native and WASM targets: `cpal` and `eframe` with `wayland` are now only included for non-WASM builds, while `web-sys` and a reduced `eframe` feature set are used for WASM builds. This ensures only necessary dependencies are included for each platform.

**Web integration improvements:**

* Updated the WASM web entry point in `src/lib.rs` to explicitly retrieve and cast the canvas element using `web_sys`, improving reliability and error handling for web initialization. The `WebRunner::start` method now receives the actual canvas element rather than just its ID, and the app creation closure now returns a `Result` for better error propagation.

**Build and configuration updates:**

* Modified the build command in `index.html` to pass `--lib` to Cargo via Trunk for more precise WASM builds.
* Added a conditional compilation directive to `src/main.rs` to ensure the file is only included in non-WASM builds, preventing conflicts when building for the web.