### PR TITLE
fix(build): WASM ビルドで bin を除外し E0601 を解消

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -43,7 +43,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build (release)
-        run: cargo build --release --locked
+        run: cargo build --features native --release --locked
 
       - name: Package (Windows)
         if: runner.os == 'Windows'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,18 @@ name = "kbd_synth_min"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+# Enable the native (desktop) binary only when this feature is set.
+native = []
+
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "kbd_synth_min"
+path = "src/main.rs"
+# Skip building the binary unless the `native` feature is enabled
+required-features = ["native"]
 
 [dependencies]
 crossbeam = "0.8.4"


### PR DESCRIPTION
This pull request introduces a new Cargo feature to control the building of the native (desktop) binary, and updates the build workflow to use this feature. These changes improve build configuration and ensure that the binary is only built when the appropriate feature is enabled.

Build configuration improvements:

* Added a `native` feature to `Cargo.toml`, allowing conditional compilation of the desktop binary. The binary (`kbd_synth_min`) will only be built if the `native` feature is enabled.
* Updated the GitHub Actions workflow (`.github/workflows/release-on-merge.yml`) to enable the `native` feature during release builds by passing `--features native` to the Cargo build command.Cargo: `features.native` を追加し `[[bin]] required-features=["native"]` を設定\nGH Actions: release ビルドを `--features native` に更新\n.gitignore: `/dist` を追加（Trunk 出力を無視）\n\nNative 実行: `cargo run --features native"\nWeb ビルド: `trunk build --release --public-url "//"`