### PR TITLE
Feature/add GitHub page for wasm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    // target
+    "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,22 @@ crossbeam = "0.8.4"
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["Window", "Document", "HtmlCanvasElement"] }
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Document",
+    "HtmlCanvasElement",
+    # WebAudio
+    "BaseAudioContext",
+    "AudioContext",
+    "AudioNode",
+    "AudioDestinationNode",
+    "AudioBuffer",
+    "ScriptProcessorNode",
+    "AudioProcessingEvent",
+    # Events
+    "EventTarget",
+    "KeyboardEvent",
+] }
 eframe = { version = "0.32.1", default-features = false, features = ["glow", "default_fonts"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,93 @@ pub mod gui {
 // WASM entry point for web build
 #[cfg(target_arch = "wasm32")]
 mod web_entry {
-    use crate::{gui::EguiUi, synth::SharedBus};
+    use crate::synth::{FilterType, Msg, SharedBus, Synth, Waveform};
+    use crate::gui::EguiUi;
     use eframe::{App, WebOptions, WebRunner};
-    use wasm_bindgen::JsCast;
     use wasm_bindgen::prelude::*;
+    use wasm_bindgen::JsCast;
+
+    use std::cell::RefCell;
+    use wasm_bindgen::closure::Closure;
+
+    thread_local! {
+        static AUDIO_CONTEXT: RefCell<Option<web_sys::AudioContext>> = RefCell::new(None);
+    }
+
+    fn init_audio(bus: SharedBus) -> Result<(), JsValue> {
+        let ctx = web_sys::AudioContext::new()?;
+        let sr = ctx.sample_rate();
+
+        // Use ScriptProcessorNode for simplicity (works broadly; low-latency enough here)
+        let buffer_size: i32 = 1024; // power of two
+        let channels_out: i32 = 2;
+        let proc = ctx
+            .create_script_processor_with_buffer_size_and_number_of_input_channels_and_number_of_output_channels(
+                buffer_size,
+                0,
+                channels_out,
+            )?;
+
+        let mut synth = Synth::new(sr, Waveform::Sine, None);
+        let bus_for_cb = bus.clone();
+        let onaudio = Closure::wrap(Box::new(move |e: web_sys::AudioProcessingEvent| {
+            // Drain bus messages
+            while let Some(msg) = bus_for_cb.q.pop() {
+                match msg {
+                    Msg::NoteOn { note } => synth.note_on(note),
+                    Msg::NoteOff { note } => synth.note_off(note),
+                    Msg::SetMasterVolume(v) => synth.set_master_volume(v),
+                    Msg::SetAdsr { a, d, s, r } => synth.set_adsr(a, d, s, r),
+                    Msg::SetWaveform(wf) => synth.set_waveform(wf),
+                    Msg::SetFilter(ft) => synth.set_filter(ft),
+                }
+            }
+
+            let output = match e.output_buffer() {
+                Some(buf) => buf,
+                None => return,
+            };
+            let frames = output.length() as usize;
+            let num_ch = output.number_of_channels() as usize;
+
+            // Generate mono then copy to all output channels
+            let mut mono = vec![0.0f32; frames];
+            for s in mono.iter_mut() {
+                *s = synth.next_sample();
+            }
+
+            for ch in 0..num_ch {
+                if let Ok(arr) = output.get_channel_data(ch as u32) {
+                    arr.copy_from(&mono);
+                }
+            }
+        }) as Box<dyn FnMut(_)>);
+
+        proc.set_onaudioprocess(Some(onaudio.as_ref().unchecked_ref()));
+        onaudio.forget(); // keep callback alive
+
+        // Connect to destination to start processing
+        proc.connect_with_audio_node(&ctx.destination())?;
+
+        // Store context so it stays alive
+        AUDIO_CONTEXT.with(|c| c.borrow_mut().replace(ctx));
+
+        // Try to resume on first user gesture (keydown / pointerdown)
+        let resume = Closure::wrap(Box::new(move || {
+            AUDIO_CONTEXT.with(|c| {
+                if let Some(ctx) = c.borrow().as_ref() {
+                    let _ = ctx.resume();
+                }
+            });
+        }) as Box<dyn FnMut()>);
+        let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+        let et: &web_sys::EventTarget = window.as_ref();
+        et.add_event_listener_with_callback("keydown", resume.as_ref().unchecked_ref())?;
+        et.add_event_listener_with_callback("pointerdown", resume.as_ref().unchecked_ref())?;
+        resume.forget(); // keep listeners alive
+
+        Ok(())
+    }
 
     // Better error messages in the browser console on panic
     #[wasm_bindgen(start)]
@@ -42,17 +125,20 @@ mod web_entry {
             .dyn_into::<web_sys::HtmlCanvasElement>()
             .map_err(|_| JsValue::from_str("failed to cast to HtmlCanvasElement"))?;
 
+        // Shared bus between UI and audio
+        let bus = SharedBus::default();
+        init_audio(bus.clone())?;
+
         let options = WebOptions::default();
         let runner = WebRunner::new();
+        let bus_for_ui = bus.clone();
         runner
             .start(
                 canvas,
                 options,
-                Box::new(
-                    |_cc| -> Result<Box<dyn App>, Box<dyn std::error::Error + Send + Sync>> {
-                        Ok(Box::new(EguiUi::new(SharedBus::default())))
-                    },
-                ),
+                Box::new(move |_cc| -> Result<Box<dyn App>, Box<dyn std::error::Error + Send + Sync>> {
+                    Ok(Box::new(EguiUi::new(bus_for_ui.clone())))
+                }),
             )
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,11 @@ pub mod gui {
 // WASM entry point for web build
 #[cfg(target_arch = "wasm32")]
 mod web_entry {
-    use crate::synth::{Msg, SharedBus, Synth, Waveform};
     use crate::gui::EguiUi;
+    use crate::synth::{Msg, SharedBus, Synth, Waveform};
     use eframe::{App, WebOptions, WebRunner};
-    use wasm_bindgen::prelude::*;
     use wasm_bindgen::JsCast;
+    use wasm_bindgen::prelude::*;
 
     use std::cell::RefCell;
     use wasm_bindgen::closure::Closure;
@@ -78,9 +78,7 @@ mod web_entry {
             }
 
             for ch in 0..num_ch {
-                if let Ok(arr) = output.get_channel_data(ch as u32) {
-                    arr.copy_from(&mono);
-                }
+                let _ = output.copy_to_channel(&mono, ch as i32);
             }
         }) as Box<dyn FnMut(_)>);
 
@@ -136,9 +134,11 @@ mod web_entry {
             .start(
                 canvas,
                 options,
-                Box::new(move |_cc| -> Result<Box<dyn App>, Box<dyn std::error::Error + Send + Sync>> {
-                    Ok(Box::new(EguiUi::new(bus_for_ui.clone())))
-                }),
+                Box::new(
+                    move |_cc| -> Result<Box<dyn App>, Box<dyn std::error::Error + Send + Sync>> {
+                        Ok(Box::new(EguiUi::new(bus_for_ui.clone())))
+                    },
+                ),
             )
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub mod gui {
 // WASM entry point for web build
 #[cfg(target_arch = "wasm32")]
 mod web_entry {
-    use crate::synth::{FilterType, Msg, SharedBus, Synth, Waveform};
+    use crate::synth::{Msg, SharedBus, Synth, Waveform};
     use crate::gui::EguiUi;
     use eframe::{App, WebOptions, WebRunner};
     use wasm_bindgen::prelude::*;
@@ -40,8 +40,8 @@ mod web_entry {
         let sr = ctx.sample_rate();
 
         // Use ScriptProcessorNode for simplicity (works broadly; low-latency enough here)
-        let buffer_size: i32 = 1024; // power of two
-        let channels_out: i32 = 2;
+        let buffer_size: u32 = 1024; // power of two
+        let channels_out: u32 = 2;
         let proc = ctx
             .create_script_processor_with_buffer_size_and_number_of_input_channels_and_number_of_output_channels(
                 buffer_size,
@@ -65,8 +65,8 @@ mod web_entry {
             }
 
             let output = match e.output_buffer() {
-                Some(buf) => buf,
-                None => return,
+                Ok(buf) => buf,
+                Err(_) => return,
             };
             let frames = output.length() as usize;
             let num_ch = output.number_of_channels() as usize;


### PR DESCRIPTION
This pull request adds WebAudio support to the WASM (web) build, enabling real-time audio synthesis in the browser. It introduces an `AudioContext` and uses a `ScriptProcessorNode` to generate audio samples, with UI and audio processing communicating via a shared message bus. The changes also expand the `web-sys` crate features to include necessary WebAudio and event APIs.

**WebAudio integration:**

* Added `init_audio` function in `src/lib.rs` to set up a `web_sys::AudioContext`, create a `ScriptProcessorNode`, and generate audio samples using the existing `Synth` logic. The function also wires up event listeners to resume audio context on user interaction.
* Established a shared `SharedBus` between UI and audio engine, allowing UI events to send messages to the audio thread for real-time synthesis control.

**Dependency updates:**

* Expanded `web-sys` features in `Cargo.toml` to include WebAudio and event APIs such as `AudioContext`, `ScriptProcessorNode`, and `KeyboardEvent`, enabling the new browser audio functionality.

**Development tooling:**

* Added `.vscode/settings.json` to specify the WASM target for `rust-analyzer`, improving editor support for web builds.