### PR TITLE
chore(web): デバッグ用 console.log を全削除（機能は維持）

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -268,6 +268,11 @@ impl App for EguiUi {
                 if repeat {
                     continue;
                 }
+                #[cfg(target_arch = "wasm32")]
+                if pressed {
+                    // Ensure AudioContext is resumed on first key press
+                    crate::web_entry::try_resume_audio();
+                }
                 let note = key.into();
                 if note == Note::None {
                     continue;


### PR DESCRIPTION
This pull request introduces improvements to the WASM audio handling for the web build, focusing on ensuring the `AudioContext` is properly resumed on user interaction and improving module visibility. The changes enhance reliability and maintainability for audio features in the web interface.

**WASM audio handling improvements:**

* Added a call to `try_resume_audio()` on first key press in `EguiUi` to ensure the `AudioContext` is resumed, addressing browser restrictions on audio playback.
* Added the `try_resume_audio()` function to `web_entry`, allowing the `AudioContext` to be resumed from anywhere in the crate.
* Added a thread-local `SCRIPT_NODE` to keep the `ScriptProcessorNode` alive, similar to how `AUDIO_CONTEXT` is managed.
* Ensured `SCRIPT_NODE` is stored and kept alive after initialization.

**Module visibility:**

* Changed the visibility of `web_entry` to `pub(crate)` to allow access to its functions (such as `try_resume_audio`) from other parts of the crate.- WebAudio/egui のログを削除\n- AudioContext の resume フックと ScriptProcessor の保持は残存\n- 動作はそのまま（WASM で発音可）